### PR TITLE
fix: prevent errors on gas simulations

### DIFF
--- a/x/feemarket/ante/fee.go
+++ b/x/feemarket/ante/fee.go
@@ -60,10 +60,12 @@ func (dfd FeeMarketCheckDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simula
 		if err != nil {
 			return ctx, errorsmod.Wrapf(err, "error checking fee")
 		}
+		priorityCtx := ctx.WithPriority(getTxPriority(fee, int64(gas))).WithMinGasPrices(minGasPrices)
+		return next(priorityCtx, tx, simulate)
 	}
 
-	newCtx := ctx.WithPriority(getTxPriority(fee, int64(gas))).WithMinGasPrices(minGasPrices)
-	return next(newCtx, tx, simulate)
+	ctx = ctx.WithMinGasPrices(minGasPrices)
+	return next(ctx, tx, simulate)
 }
 
 // CheckTxFees implements the logic for the fee market to check if a Tx has provided sufficient

--- a/x/feemarket/ante/fee_test.go
+++ b/x/feemarket/ante/fee_test.go
@@ -37,6 +37,24 @@ func TestAnteHandle(t *testing.T) {
 			ExpPass:  false,
 			ExpErr:   sdkerrors.ErrInvalidGasLimit,
 		},
+		// test --gas=auto flag settings
+		// when --gas=auto is set, cosmos-sdk sets gas=0 and simulate=true
+		{
+			Name: "--gas=auto behaviour test",
+			Malleate: func(suite *antesuite.TestSuite) antesuite.TestCaseArgs {
+				accs := suite.CreateTestAccounts(1)
+
+				return antesuite.TestCaseArgs{
+					Msgs:      []sdk.Msg{testdata.NewTestMsg(accs[0].Account.GetAddress())},
+					GasLimit:  0,
+					FeeAmount: validFee,
+				}
+			},
+			RunAnte:  true,
+			RunPost:  false,
+			Simulate: true,
+			ExpPass:  true,
+		},
 		{
 			Name: "signer has enough funds, should pass",
 			Malleate: func(suite *antesuite.TestSuite) antesuite.TestCaseArgs {


### PR DESCRIPTION
This PR offers a possible solution to https://github.com/skip-mev/feemarket/issues/69.

Closes: https://github.com/skip-mev/feemarket/issues/69

TLDR;
There are zero dicision erros when using the feemarket antehandler with `--gas=auto` flags. This PR tries to fix the error and adds some tests.