### PR TITLE
chore: fix aimd fuzz testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,3 +54,23 @@ jobs:
         if: env.GIT_DIFF
         run: |
           make test-integration
+  test-fuzz:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
+        with:
+          go-version: 1.22.3
+          cache: true
+          cache-dependency-path: go.sum
+      - uses: technote-space/get-diff-action@v6.1.2
+        id: git_diff
+        with:
+          PATTERNS: |
+            **/*.go
+            go.mod
+            go.sum
+      - name: tests
+        if: env.GIT_DIFF
+        run: |
+          make fuzz

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,4 +73,4 @@ jobs:
       - name: tests
         if: env.GIT_DIFF
         run: |
-          make fuzz
+          make test-fuzz

--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,9 @@ test-e2e: $(TEST_E2E_DEPS)
 test-unit:
 	@go test -v -race $(shell go list ./... | grep -v tests/)
 
+test-fuzz:
+	@cd ./x/feemarket/fuzz && go test -v -race -rapid.checks=100_000 -p 4
+
 test-integration:
 	@go test -v -race ./tests/integration
 
@@ -140,7 +143,7 @@ test-cover:
 	@go tool cover -html=$(COVER_FILE) -o $(COVER_HTML_FILE)
 	@rm $(COVER_FILE)
 
-test-all: test-unit test-integration test-e2e
+test-all: test-unit test-integration test-e2e test-fuzz
 
 .PHONY: test-unit test-e2e test-integration test-cover test-all
 

--- a/x/feemarket/fuzz/aimd_eip1559_test.go
+++ b/x/feemarket/fuzz/aimd_eip1559_test.go
@@ -1,6 +1,7 @@
 package fuzz_test
 
 import (
+	"fmt"
 	"testing"
 
 	"cosmossdk.io/math"
@@ -59,7 +60,7 @@ func TestAIMDLearningRate(t *testing.T) {
 	})
 }
 
-// TestAIMDBaseFee ensure's that the additive increase multiplicative
+// TestAIMDBaseFee ensures that the additive increase multiplicative
 // decrease base fee adjustment algorithm correctly adjusts the base
 // fee. In particular, the base fee should function the same as the
 // default EIP-1559 base fee adjustment algorithm.
@@ -89,14 +90,14 @@ func TestAIMDBaseFee(t *testing.T) {
 			// Update the base gas price.
 			state.UpdateBaseGasPrice(params)
 
-			// Ensure that the minimum base fee is always less than the base fee.
+			// Ensure that the minimum base fee is always less than the base gas price.
 			require.True(t, params.MinBaseGasPrice.LTE(state.BaseGasPrice))
 
 			switch {
 			case blockUtilization > params.TargetBlockUtilization:
-				require.True(t, state.BaseGasPrice.GTE(prevBaseGasPrice))
+				require.True(t, state.BaseGasPrice.GTE(prevBaseGasPrice), fmt.Sprintf("base gas price %v, prev gas price %v, gas %v", state.BaseGasPrice, prevBaseGasPrice, blockUtilization))
 			case blockUtilization < params.TargetBlockUtilization:
-				require.True(t, state.BaseGasPrice.LTE(prevBaseGasPrice))
+				require.True(t, state.BaseGasPrice.LTE(prevBaseGasPrice), fmt.Sprintf("base gas price %v, prev gas price %v, gas %v", state.BaseGasPrice, prevBaseGasPrice, blockUtilization))
 			default:
 
 				// Account for the delta adjustment.


### PR DESCRIPTION
AIMD fuzz testing conditions were incorrectly using only the current block utilization (copy paste from the default 1559 tests)

This PR refactors the tests so that they:
- check for unnecessary panics
- verify calculations and determinism