### PR TITLE
fix: tx prioritization 

### DIFF
--- a/tests/e2e/consumer.go
+++ b/tests/e2e/consumer.go
@@ -35,7 +35,7 @@ func CCVChainConstructor(t *testing.T, spec *interchaintest.ChainSpec) []*cosmos
 				NumValidators: &providerNumValidators,
 				ChainConfig: ibc.ChainConfig{
 					GasPrices:      "1uatom",
-					GasAdjustment:  1.5,
+					GasAdjustment:  0.0,
 					ChainID:        providerChainID,
 					TrustingPeriod: "336h",
 					ModifyGenesis: cosmos.ModifyGenesis(

--- a/tests/e2e/consumer.go
+++ b/tests/e2e/consumer.go
@@ -43,7 +43,8 @@ func CCVChainConstructor(t *testing.T, spec *interchaintest.ChainSpec) []*cosmos
 							cosmos.NewGenesisKV("app_state.provider.params.blocks_per_epoch", "1"),
 						},
 					),
-				}},
+				},
+			},
 		},
 	)
 

--- a/tests/e2e/consumer.go
+++ b/tests/e2e/consumer.go
@@ -34,7 +34,7 @@ func CCVChainConstructor(t *testing.T, spec *interchaintest.ChainSpec) []*cosmos
 				Version:       providerVersion,
 				NumValidators: &providerNumValidators,
 				ChainConfig: ibc.ChainConfig{
-					GasPrices:      "1uatom",
+					GasPrices:      "0uatom",
 					GasAdjustment:  0.0,
 					ChainID:        providerChainID,
 					TrustingPeriod: "336h",

--- a/x/feemarket/ante/fee.go
+++ b/x/feemarket/ante/fee.go
@@ -113,12 +113,12 @@ func (dfd feeMarketCheckDecorator) anteHandle(ctx sdk.Context, tx sdk.Tx, simula
 	ctx = ctx.WithMinGasPrices(sdk.NewDecCoins(minGasPrice))
 
 	if !simulate {
-		fee, tip, err := CheckTxFee(ctx, minGasPrice, feeCoin, feeGas, true)
+		_, _, err := CheckTxFee(ctx, minGasPrice, feeCoin, feeGas, true)
 		if err != nil {
 			return ctx, errorsmod.Wrapf(err, "error checking fee")
 		}
 
-		priorityFee, err := dfd.resolveTxPriorityCoins(ctx, fee.Add(tip), params.FeeDenom)
+		priorityFee, err := dfd.resolveTxPriorityCoins(ctx, feeCoin, params.FeeDenom)
 		if err != nil {
 			return ctx, errorsmod.Wrapf(err, "error resolving fee priority")
 		}
@@ -217,9 +217,7 @@ func GetTxPriority(fee sdk.Coin, gasLimit int64, currentGasPrice sdk.DecCoin) in
 	// overflow panic protection
 	if scaledGasPrice.GTE(sdkmath.LegacyNewDec(math.MaxInt64)) {
 		return math.MaxInt64
-	}
-
-	if scaledGasPrice.LTE(sdkmath.LegacyOneDec()) {
+	} else if scaledGasPrice.LTE(sdkmath.LegacyOneDec()) {
 		return 0
 	}
 

--- a/x/feemarket/ante/fee.go
+++ b/x/feemarket/ante/fee.go
@@ -165,6 +165,7 @@ func CheckTxFee(ctx sdk.Context, minGasPrice sdk.DecCoin, feeCoin sdk.Coin, feeG
 
 		consumedFeeAmount := minGasPrice.Amount.Mul(gcDec)
 		limitFee := minGasPrice.Amount.Mul(glDec)
+
 		consumedFee = sdk.NewCoin(minGasPrice.Denom, consumedFeeAmount.Ceil().RoundInt())
 		requiredFee = sdk.NewCoin(minGasPrice.Denom, limitFee.Ceil().RoundInt())
 
@@ -180,12 +181,9 @@ func CheckTxFee(ctx sdk.Context, minGasPrice sdk.DecCoin, feeCoin sdk.Coin, feeG
 
 		if isAnte {
 			tip = payCoin.Sub(requiredFee)
-			//  set fee coins to be required amount if checking
 			payCoin = requiredFee
 		} else {
-			// tip is the difference between payCoin and the required fee
-			tip = payCoin.Sub(requiredFee)
-			// set fee coin to be ONLY the consumed amount if we are calculated consumed fee to deduct
+			tip = payCoin.Sub(consumedFee)
 			payCoin = consumedFee
 		}
 	}

--- a/x/feemarket/fuzz/tx_priority_test.go
+++ b/x/feemarket/fuzz/tx_priority_test.go
@@ -21,7 +21,7 @@ type input struct {
 // TestGetTxPriority ensures that tx priority is properly bounded
 func TestGetTxPriority(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
-		inputs := CreateRandomInput(t)
+		inputs := createRandomInput(t)
 
 		priority := ante.GetTxPriority(inputs.payFee, inputs.gasLimit, inputs.currentGasPrice)
 		require.GreaterOrEqual(t, priority, int64(0))
@@ -30,7 +30,7 @@ func TestGetTxPriority(t *testing.T) {
 }
 
 // CreateRandomInput returns a random inputs to the priority function.
-func CreateRandomInput(t *rapid.T) input {
+func createRandomInput(t *rapid.T) input {
 	denom := "skip"
 
 	price := rapid.Int64Range(1, 1_000_000_000).Draw(t, "gas price")

--- a/x/feemarket/fuzz/tx_priority_test.go
+++ b/x/feemarket/fuzz/tx_priority_test.go
@@ -1,0 +1,47 @@
+package fuzz_test
+
+import (
+	"math"
+	"testing"
+
+	sdkmath "cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+	"pgregory.net/rapid"
+
+	"github.com/skip-mev/feemarket/x/feemarket/ante"
+)
+
+type input struct {
+	payFee          sdk.Coin
+	gasLimit        int64
+	currentGasPrice sdk.DecCoin
+}
+
+// TestGetTxPriority ensures that tx priority is properly bounded
+func TestGetTxPriority(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		inputs := CreateRandomInput(t)
+
+		priority := ante.GetTxPriority(inputs.payFee, inputs.gasLimit, inputs.currentGasPrice)
+		require.GreaterOrEqual(t, priority, 0)
+		require.LessOrEqual(t, priority, math.MaxInt64)
+	})
+}
+
+// CreateRandomInput returns a random inputs to the priority function.
+func CreateRandomInput(t *rapid.T) input {
+	denom := "skip"
+
+	price := rapid.Int64Range(1, math.MaxInt64).Draw(t, "gas price")
+	gasLimit := rapid.Int64Range(1, math.MaxInt64).Draw(t, "gas limit")
+	priceDec := sdkmath.LegacyNewDecWithPrec(price, 1000)
+
+	payFeeAmt := rapid.Int64Range(priceDec.MulInt64(gasLimit).TruncateInt64(), math.MaxInt64).Draw(t, "fee amount")
+
+	return input{
+		payFee:          sdk.NewCoin(denom, sdkmath.NewInt(payFeeAmt)),
+		gasLimit:        gasLimit,
+		currentGasPrice: sdk.NewDecCoinFromDec(denom, priceDec),
+	}
+}

--- a/x/feemarket/post/fee_test.go
+++ b/x/feemarket/post/fee_test.go
@@ -5,13 +5,11 @@ import (
 	"testing"
 
 	"cosmossdk.io/math"
-
 	"github.com/cosmos/cosmos-sdk/testutil/testdata"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/stretchr/testify/mock"
-
-	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	antesuite "github.com/skip-mev/feemarket/x/feemarket/ante/suite"
 	"github.com/skip-mev/feemarket/x/feemarket/post"
@@ -154,7 +152,8 @@ func TestPostHandle(t *testing.T) {
 		resolvableDenom = "atom"
 	)
 
-	gasLimit := antesuite.NewTestGasLimit()
+	// exact cost of transaction
+	gasLimit := uint64(27284)
 	validFeeAmount := types.DefaultMinBaseGasPrice.MulInt64(int64(gasLimit))
 	validFeeAmountWithTip := validFeeAmount.Add(math.LegacyNewDec(100))
 	validFee := sdk.NewCoins(sdk.NewCoin(baseDenom, validFeeAmount.TruncateInt()))


### PR DESCRIPTION
- pass the entire pay amount (amount used in `--fee`) into the txPriority calculation. This incorporates a notion of "payment over the base fee" that is used to actually derive your priority.  We retain dividing by `gas limit` so that priority is denominated in "gas price"
- the `Coin` passed into the priority calculation will always be resolved to the `feemarket` base fee.  This calculation is always truncated when going from DecCoins to Coins
- Refactor `GetTxPriority` to scale the values to integers.  Previously, when gasPrices were  < 1, nearly all priorities would just be truncated to 0.  Added fuzz testing around this 