### PR TITLE
bug: Don't fail ante handler on simulate tx with no fee

### DIFF
--- a/x/feemarket/ante/fee_test.go
+++ b/x/feemarket/ante/fee_test.go
@@ -77,6 +77,23 @@ func TestAnteHandle(t *testing.T) {
 			ExpErr:   sdkerrors.ErrOutOfGas,
 		},
 		{
+			Name: "0 gas given should pass in simulate",
+			Malleate: func(suite *antesuite.TestSuite) antesuite.TestCaseArgs {
+				accs := suite.CreateTestAccounts(1)
+
+				return antesuite.TestCaseArgs{
+					Msgs:      []sdk.Msg{testdata.NewTestMsg(accs[0].Account.GetAddress())},
+					GasLimit:  0,
+					FeeAmount: nil,
+				}
+			},
+			RunAnte:  true,
+			RunPost:  false,
+			Simulate: true,
+			ExpPass:  true,
+			ExpErr:   nil,
+		},
+		{
 			Name: "signer has enough funds, should pass",
 			Malleate: func(suite *antesuite.TestSuite) antesuite.TestCaseArgs {
 				accs := suite.CreateTestAccounts(1)


### PR DESCRIPTION
We didn't intend to deny simulate requests with no fee set, but the only way we previously tested it was with a valid fee, but gas=auto it seems.

I've tried to case around the simulate in the ante handler so that min gas price still gets set on the context, but we don't fail on no fee coins in the tx.