### PR TITLE
docs(tools): update Go wiki link

### DIFF
--- a/tools/tools.go
+++ b/tools/tools.go
@@ -5,7 +5,7 @@ package tools
 
 // Manage tool dependencies via go.mod.
 //
-// https://github.com/golang/go/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module
+// https://go.dev/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module
 // https://github.com/golang/go/issues/25922
 
 //nolint:all


### PR DESCRIPTION
Go wiki doesn't exit any more on GitHub