### PR TITLE
fix(perf): no info logging in ante/post handlers.

### DIFF
--- a/x/feemarket/ante/fee.go
+++ b/x/feemarket/ante/fee.go
@@ -122,7 +122,7 @@ func (dfd feeMarketCheckDecorator) anteHandle(ctx sdk.Context, tx sdk.Tx, simula
 		return ctx, errorsmod.Wrapf(err, "unable to get min gas price for denom %s", payCoin.GetDenom())
 	}
 
-	ctx.Logger().Info("fee deduct ante handle",
+	ctx.Logger().Debug("fee deduct ante handle",
 		"min gas prices", minGasPrice,
 		"fee", feeCoins,
 		"gas limit", gas,

--- a/x/feemarket/post/fee.go
+++ b/x/feemarket/post/fee.go
@@ -109,7 +109,7 @@ func (dfd FeeMarketDeductDecorator) PostHandle(ctx sdk.Context, tx sdk.Tx, simul
 		return ctx, errorsmod.Wrapf(err, "unable to get min gas price for denom %s", payCoin.GetDenom())
 	}
 
-	ctx.Logger().Info("fee deduct post handle",
+	ctx.Logger().Debug("fee deduct post handle",
 		"min gas prices", minGasPrice,
 		"gas consumed", gas,
 	)
@@ -121,7 +121,7 @@ func (dfd FeeMarketDeductDecorator) PostHandle(ctx sdk.Context, tx sdk.Tx, simul
 		}
 	}
 
-	ctx.Logger().Info("fee deduct post handle",
+	ctx.Logger().Debug("fee deduct post handle",
 		"fee", payCoin,
 		"tip", tip,
 	)


### PR DESCRIPTION
We've done some load-testing and profiling in gaia, and it turns out that these log lines use up a huge amount of CPU time.

We collected the following flamegraph over a Cosmos Hub testnet experiment that ran hundreds of transactions per second on a ~40-validator chain. This is an aggregate of all validators' CPU profiling data over about 10m at peak load. I sandwiched into `runTx`, so widths are relative to time spent running transactions. Stack frames that match "Zerolog" are highlighted:

![Screenshot 2025-04-23 at 4 19 45 PM](https://github.com/user-attachments/assets/7b5aefe4-90a3-4e51-a52f-5e1a43fc3d38)

As you can see there's two big flames sticking out of feemarket's ante and post handlers because of these log lines. Indeed, each of those uses about 8% of `runTx`'s CPU time, meaning that 16% of CPU cycles spent processing transactions are actually just spent logging those transactions' gas usage. Since ante handlers execute sequentially, these are cycles stolen from the next transaction in the queue.