### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ictest.yml
+++ b/.github/workflows/ictest.yml
@@ -5,6 +5,8 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
 jobs:
   e2e:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/skip-mev/feemarket/security/code-scanning/2](https://github.com/skip-mev/feemarket/security/code-scanning/2)

To fix this issue, you should add a `permissions` block specifying the least privilege needed for the workflow. Since all steps in this job only require reading repository contents (for actions/checkout, reading code, etc.) and do not need to create or modify any resources, you should add a `permissions` block with `contents: read` at the workflow root (above `jobs:`). This will ensure the GITHUB_TOKEN only has read access to repository contents for all jobs in the workflow (in this case, just `e2e`). No other changes are required. The change should be made in the `.github/workflows/ictest.yml` file, just prior to the `jobs:` key (i.e., after the `on:` block).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
